### PR TITLE
Add Redis implementation of RestartInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 
 * `RedisRestart` - implementation of `RestartInterface` allowing graceful shutdown of Hermes through Redis entry.
+* **BREAKING CHANGE**: Added `RestartInterface::restart()` method to initiate Hermes restart without knowing the requirements of used `RestartInterface` implementation. _Updated all related tests._
 
 ## 2.2.0 - 2019-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Added
+
+* `RedisRestart` - implementation of `RestartInterface` allowing graceful shutdown of Hermes through Redis entry.
+
 ## 2.2.0 - 2019-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,13 +261,11 @@ $restart = Tomaj\Hermes\Restart\SharedFileRestart($restartFile);
 // $log = ...
 // $driver = ....
 $dispatcher = new Dispatcher($driver, $log, $restart);
-```
 
-And then:
+// ...
 
-```php
-// initiate shutdown; eg. from PHP application
-touch($restartFile, time());
+// restart can be triggered be calling `RestartInteface::restart()`
+$restart->restart();
 ```
 
 ### RedisRestart
@@ -282,13 +280,11 @@ $restart = Tomaj\Hermes\Restart\RedisRestart($redisClient, $redisRestartKey);
 // $log = ...
 // $driver = ....
 $dispatcher = new Dispatcher($driver, $log, $restart);
-```
 
-And then:
+// ...
 
-```php
-// initiate shutdown; eg. from PHP application
-$redisClient->set($redisRestartKey, time());
+// restart can be triggered be calling `RestartInteface::restart()`
+$restart->restart();
 ```
 
 ## Scaling Hermes

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -106,7 +106,7 @@ class Dispatcher implements DispatcherInterface
                 return $result;
             });
         } catch (RestartException $e) {
-            $this->log(LogLevel::NOTICE, 'Existing hermes dispatcher - restart');
+            $this->log(LogLevel::NOTICE, 'Exiting hermes dispatcher - restart');
         } catch (Exception $exception) {
             if (Debugger::isEnabled()) {
                 Debugger::log($exception, Debugger::EXCEPTION);

--- a/src/Restart/RedisRestart.php
+++ b/src/Restart/RedisRestart.php
@@ -59,4 +59,18 @@ class RedisRestart implements RestartInterface
 
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Sets to Redis value `$restartTime` (or current DateTime) to `$key` defined in constructor.
+     */
+    public function restart(DateTime $restartTime = null): bool
+    {
+        if ($restartTime === null) {
+            $restartTime = new DateTime();
+        }
+
+        return $this->redis->set($this->key, $restartTime->format('U'));
+    }
 }

--- a/src/Restart/RedisRestart.php
+++ b/src/Restart/RedisRestart.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Tomaj\Hermes\Restart;
+
+use DateTime;
+use InvalidArgumentException;
+
+/**
+ * Class RedisRestart provides redis implementation of Tomaj\Hermes\Restart\RestartInterface
+ *
+ * Set UNIX timestamp (as `string`) to key `$key` (default `hermes_restart`) to restart Hermes.
+ */
+class RedisRestart implements RestartInterface
+{
+    /** @var string */
+    private $key;
+
+    /** @var \Predis\Client|\Redis */
+    private $redis;
+
+    public function __construct($redis, string $key = 'hermes_restart')
+    {
+        if (!(($redis instanceof \Predis\Client) || ($redis instanceof \Redis))) {
+            throw new InvalidArgumentException('Predis\Client or Redis instance required');
+        }
+
+        $this->key = $key;
+        $this->redis = $redis;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Returns true:
+     *
+     * - if restart timestamp is set,
+     * - and timestamp is not in future,
+     * - and hermes was started ($startTime) before timestamp
+     */
+    public function shouldRestart(DateTime $startTime): bool
+    {
+        // load UNIX timestamp from redis
+        $restartTime = $this->redis->get($this->key);
+        if ($restartTime === null) {
+            return false;
+        }
+        $restartTime = (int) $restartTime;
+
+        // do not restart if restart time is in future
+        if ($restartTime > time()) {
+            return false;
+        }
+
+        // do not restart if hermes started after restart time
+        if ($restartTime < $startTime->getTimestamp()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Restart/RestartInterface.php
+++ b/src/Restart/RestartInterface.php
@@ -11,10 +11,20 @@ interface RestartInterface
      * Basic restart function.
      *
      * You have to return true or false if hermes worker should restart.
-     * This method is called from Dispatcher always after messages was procesed
+     * This method is called from Dispatcher always after messages were processed
      *
      * @param DateTime $startTime
      * @return bool
      */
     public function shouldRestart(DateTime $startTime): bool;
+
+    /**
+     * Initiate restart.
+     *
+     * This function performs necessary operations required to restart Hermes through used implementation.
+     *
+     * @param DateTime $restartTime (Optional) DateTime when should be Hermes restarted. If null, current datetime should be used.
+     * @return bool
+     */
+    public function restart(DateTime $restartTime = null): bool;
 }

--- a/src/Restart/SharedFileRestart.php
+++ b/src/Restart/SharedFileRestart.php
@@ -30,4 +30,18 @@ class SharedFileRestart implements RestartInterface
 
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Creates file defined in contructor with modification time `$restartTime` (or current DateTime).
+     */
+    public function restart(DateTime $restartTime = null): bool
+    {
+        if ($restartTime === null) {
+            $restartTime = new DateTime();
+        }
+
+        return touch($this->filePath, (int) $restartTime->format('U'));
+    }
 }

--- a/tests/Restart/DispatcherRestartTest.php
+++ b/tests/Restart/DispatcherRestartTest.php
@@ -12,13 +12,34 @@ use Tomaj\Hermes\Test\Restart\StopRestart;
 
 class HandleRestartTest extends PHPUnit_Framework_TestCase
 {
-    public function testEmitWithDummyDriver()
+    public function testEmitWithDummyDriverNoRestart()
     {
         $message1 = new Message('event1', ['a' => 'b']);
         $message2 = new Message('event1', ['c' => 'd']);
 
         $driver = new DummyDriver([$message1, $message2]);
-        $stopRestart = new StopRestart(1);
+        $stopRestart = new StopRestart();
+        $dispatcher = new Dispatcher($driver, null, $stopRestart);
+
+        $handler = new TestHandler();
+
+        $dispatcher->registerHandler('event1', $handler);
+
+        $dispatcher->handle();
+
+        $receivedMessages = $handler->getReceivedMessages();
+        // no restart; we received both messages
+        $this->assertEquals(2, count($receivedMessages));
+    }
+
+    public function testEmitWithDummyDriverWithRestart()
+    {
+        $message1 = new Message('event1', ['a' => 'b']);
+        $message2 = new Message('event1', ['c' => 'd']);
+
+        $driver = new DummyDriver([$message1, $message2]);
+        $stopRestart = new StopRestart();
+        $stopRestart->restart(new \DateTime());
         $dispatcher = new Dispatcher($driver, null, $stopRestart);
 
         $handler = new TestHandler();

--- a/tests/Restart/RedisRestartTest.php
+++ b/tests/Restart/RedisRestartTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tomaj\Hermes\Test;
+
+use PHPUnit_Framework_TestCase;
+use Tomaj\Hermes\Restart\RedisRestart;
+
+class RedisRestartTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testNoRedis()
+    {
+        $redis = null;
+        $this->setExpectedException('InvalidArgumentException', 'Predis\Client or Redis instance required');
+        new RedisRestart($redis);
+    }
+
+    public function testNoEntry()
+    {
+        $redis = $this->getMock('\Redis', ['get']);
+        $redis->expects($this->once())
+            ->method('get')
+            ->willReturn(null);
+
+        $redisRestart = new RedisRestart($redis);
+        $this->assertFalse($redisRestart->shouldRestart(new \DateTime()));
+    }
+
+    public function testFutureEntry()
+    {
+        $futureTime = (new \DateTime())->modify('+1 month')->format('U');
+        $redis = $this->getMock('\Redis', ['get']);
+        $redis->expects($this->once())
+            ->method('get')
+            ->with('hermes_restart')
+            ->willReturn($futureTime);
+
+        $redisRestart = new RedisRestart($redis);
+        $this->assertFalse($redisRestart->shouldRestart(new \DateTime()));
+    }
+
+    public function testEntryAfterStartTime()
+    {
+        $pastTime = (new \DateTime())->modify('-1 month')->format('U');
+        $redis = $this->getMock('\Redis', ['get']);
+        $redis->expects($this->once())
+            ->method('get')
+            ->with('hermes_restart')
+            ->willReturn($pastTime);
+
+        $redisRestart = new RedisRestart($redis);
+        $this->assertFalse($redisRestart->shouldRestart(new \DateTime()));
+    }
+
+    public function testSuccess()
+    {
+        $startTime = (new \DateTime())->modify('-1 hour');
+        $restartTime = (new \DateTime())->modify('-5 minutes')->format('U');
+        $redis = $this->getMock('\Redis', ['get']);
+        $redis->expects($this->once())
+            ->method('get')
+            ->with('hermes_restart')
+            ->willReturn($restartTime);
+
+        $redisRestart = new RedisRestart($redis);
+        $this->assertTrue($redisRestart->shouldRestart($startTime));
+    }
+}

--- a/tests/Restart/SharedFileRestartTest.php
+++ b/tests/Restart/SharedFileRestartTest.php
@@ -9,21 +9,43 @@ use DateTime;
 
 class SharedFileRestartTest extends PHPUnit_Framework_TestCase
 {
-    public function testWithNotExistsingFile()
+    public function testShouldRestartWithNotExistsingFile()
     {
-        $sharedRestart1 = new SharedFileRestart('unknownfilepath.txt');
-        $this->assertFalse($sharedRestart1->shouldRestart(new DateTime()));
+        $sharedFileRestart = new SharedFileRestart('unknownfilepath.txt');
+        $this->assertFalse($sharedFileRestart->shouldRestart(new DateTime()));
     }
 
-    public function testWithNewFile()
+    public function testShouldRestartWithNewFile()
     {
-        $sharedRestart1 = new SharedFileRestart(tempnam(sys_get_temp_dir(), 'hermestest'));
-        $this->assertTrue($sharedRestart1->shouldRestart(new DateTime('-3 minutes')));
+        $sharedFileRestart = new SharedFileRestart(tempnam(sys_get_temp_dir(), 'hermestest'));
+        $this->assertTrue($sharedFileRestart->shouldRestart(new DateTime('-3 minutes')));
     }
 
-    public function testWithOldFile()
+    public function testShouldRestartWithOldFile()
     {
-        $sharedRestart1 = new SharedFileRestart(tempnam(sys_get_temp_dir(), 'hermestest'));
-        $this->assertFalse($sharedRestart1->shouldRestart(new DateTime('+3 minutes')));
+        $sharedFileRestart = new SharedFileRestart(tempnam(sys_get_temp_dir(), 'hermestest'));
+        $this->assertFalse($sharedFileRestart->shouldRestart(new DateTime('+3 minutes')));
+    }
+
+    public function testRestartCreatedCorrectFile()
+    {
+        $fileName = sys_get_temp_dir() . '/hermestest_restart_' . time();
+        $sharedFileRestart = new SharedFileRestart($fileName);
+
+        $this->assertFalse(file_exists($fileName));
+
+        // try to initiate restart Hermes
+        $restartTime = new DateTime();
+        $this->assertTrue($sharedFileRestart->restart($restartTime));
+
+        $this->assertTrue(file_exists($fileName));
+
+        $fileModificationTime = filemtime($fileName);
+        $this->assertNotFalse($fileModificationTime);
+
+        $this->assertEquals($restartTime->format('U'), $fileModificationTime);
+
+        // clean after test
+        unlink($fileName);
     }
 }

--- a/tests/Restart/StopRestart.php
+++ b/tests/Restart/StopRestart.php
@@ -8,19 +8,20 @@ use Tomaj\Hermes\Restart\RestartInterface;
 
 class StopRestart implements RestartInterface
 {
-    private $eventsStop;
-
-    public function __construct(int $eventsStop = 1)
-    {
-        $this->eventsStop = $eventsStop;
-    }
+    static private $eventsStop;
 
     public function shouldRestart(DateTime $startTime): bool
     {
-        if ($this->eventsStop == 1) {
+        if (self::$eventsStop === 1) {
             return true;
         }
-        $this->eventsStop--;
+        self::$eventsStop--;
         return false;
+    }
+
+    public function restart(DateTime $restartTime = null): bool
+    {
+        self::$eventsStop = 1;
+        return true;
     }
 }


### PR DESCRIPTION
Allows to gracefully shutdown Hermes through value in Redis.

Added:
- `\Tomaj\Hermes\Restart\RedisRestart` + tests
- Little bit of documentation in README 
- Fixed typo in `\Tomaj\Hermes\Dispatcher`

Details:
- Redis `key` is configurable.
- Value in redis is UNIX timestamp.
- Shutdown is initiated only if timestamp from redis is in past but it's newer than Hermes start time.

Tests:
- This one test works `php vendor/bin/phpunit --filter="RedisRestartTest"`
- There are some issues with tests under PHP 7.3 so running all tests (`make test`) fails.