### PR TITLE
Added support for softrestarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+* Added support for *soft restart* to all drivers
+* Added `consumer tag` to LazyRabbitMq driver for consumer
+* Added support for _max items_ and _restart_ for LazyRabbitMq Driver
+* updated restart policy for AmazonSQS Driver  
+
+
 ## 3.0.1 - 2020-10-16
 
 ### Changed

--- a/examples/rabbitmq/emitter.php
+++ b/examples/rabbitmq/emitter.php
@@ -1,19 +1,19 @@
 <?php
 declare(strict_types=1);
 
-use Tomaj\Hermes\Driver\RabbitMqDriver;
+
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use Tomaj\Hermes\Driver\LazyRabbitMqDriver;
 use Tomaj\Hermes\Emitter;
 use Tomaj\Hermes\Message;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+
 
 require_once __DIR__.'/../../vendor/autoload.php';
 
 
 $queueName = 'hermes_queue';
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest', '/');
-$channel = $connection->channel();
-$channel->queue_declare($queueName, false, false, false, false);
-$driver = new RabbitMqDriver($channel, $queueName);
+$connection = new AMQPLazyConnection('localhost', 5672, 'guest', 'guest', '/');
+$driver = new LazyRabbitMqDriver($connection, $queueName);
 
 $emitter = new Emitter($driver);
 

--- a/examples/rabbitmq/processor.php
+++ b/examples/rabbitmq/processor.php
@@ -1,19 +1,16 @@
 <?php
 declare(strict_types=1);
 
-use Tomaj\Hermes\Driver\RabbitMqDriver;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use Tomaj\Hermes\Driver\LazyRabbitMqDriver;
 use Tomaj\Hermes\Dispatcher;
 use Tomaj\Hermes\Handler\EchoHandler;
 
 require_once __DIR__.'/../../vendor/autoload.php';
 
 $queueName = 'hermes_queue';
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest', '/guest');
-$channel = $connection->channel();
-$channel->queue_declare($queueName, false, false, false, false);
-$driver = new RabbitMqDriver($channel, $queueName);
-
+$connection = new AMQPLazyConnection('localhost', 5672, 'guest', 'guest', '/');
+$driver = new LazyRabbitMqDriver($connection, $queueName, [], 0);
 
 $dispatcher = new Dispatcher($driver);
 

--- a/examples/redis/processor.php
+++ b/examples/redis/processor.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 use Tomaj\Hermes\Driver\RedisSetDriver;
 use Tomaj\Hermes\Dispatcher;
 use Tomaj\Hermes\Handler\EchoHandler;
+use Tomaj\Hermes\Restart\RedisRestart;
 
 require_once __DIR__.'/../../vendor/autoload.php';
 
 $redis = new Redis();
 $redis->connect('127.0.0.1', 6379);
-$driver = new RedisSetDriver($redis, 'hermes');
+$driver = new RedisSetDriver($redis, 'hermes', 1);
+$driver->setRestart(new RedisRestart($redis));
 
 $dispatcher = new Dispatcher($driver);
 

--- a/examples/redis/restart.php
+++ b/examples/redis/restart.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use Tomaj\Hermes\Restart\RedisRestart;
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+$redis = new Redis();
+$redis->connect('127.0.0.1', 6379);
+(new RedisRestart($redis))->restart();

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,6 +6,7 @@ namespace Tomaj\Hermes;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Tomaj\Hermes\Driver\RestartTrait;
 use Tomaj\Hermes\Handler\HandlerInterface;
 use Tomaj\Hermes\Driver\DriverInterface;
 use Tomaj\Hermes\Restart\RestartException;
@@ -61,6 +62,10 @@ class Dispatcher implements DispatcherInterface
         $this->logger = $logger;
         $this->restart = $restart;
         $this->startTime = new DateTime();
+
+        if ($restart && method_exists($this->driver, 'setRestart')) {
+            $this->driver->setRestart($restart);
+        }
     }
 
     /**

--- a/src/Driver/AmazonSqsDriver.php
+++ b/src/Driver/AmazonSqsDriver.php
@@ -103,24 +103,21 @@ class AmazonSqsDriver implements DriverInterface
     public function wait(Closure $callback): void
     {
         while (true) {
+            $this->checkRestart();
             if (!$this->shouldProcessNext()) {
                 break;
             }
-            $this->checkRestart();
 
             $result = $this->client->receiveMessage([
                 'QueueUrl' => $this->queueUrl,
                 'WaitTimeSeconds' => 1,
             ]);
 
-//            var_dump($result);
-
             $messages = $result['Messages'];
 
             if ($messages) {
                 $hermesMessages = [];
                 foreach ($messages as $message) {
-//                    var_dump($message);
                     $this->client->deleteMessage([
                         'QueueUrl' => $this->queueUrl,
                         'ReceiptHandle' => $message['ReceiptHandle'],

--- a/src/Driver/AmazonSqsDriver.php
+++ b/src/Driver/AmazonSqsDriver.php
@@ -128,11 +128,11 @@ class AmazonSqsDriver implements DriverInterface
                     $callback($hermesMessage);
                     $this->incrementProcessedItems();
                 }
-            }
-
-            if ($this->sleepInterval) {
-                $this->checkRestart();
-                sleep($this->sleepInterval);
+            } else {
+                if ($this->sleepInterval) {
+                    $this->checkRestart();
+                    sleep($this->sleepInterval);
+                }
             }
         }
     }

--- a/src/Driver/RedisSetDriver.php
+++ b/src/Driver/RedisSetDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Tomaj\Hermes\Driver;
 
@@ -85,10 +86,10 @@ class RedisSetDriver implements DriverInterface
     public function wait(Closure $callback): void
     {
         while (true) {
+            $this->checkRestart();
             if (!$this->shouldProcessNext()) {
                 break;
             }
-            $this->checkRestart();
 
             // check schedule
             $messagesString = [];

--- a/src/Driver/RestartTrait.php
+++ b/src/Driver/RestartTrait.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Tomaj\Hermes\Driver;
+
+use Tomaj\Hermes\Restart\RestartException;
+use Tomaj\Hermes\Restart\RestartInterface;
+
+trait RestartTrait
+{
+    /** @var RestartInterface */
+    private $restart;
+
+    private $startTime;
+
+    public function setRestart(RestartInterface $restart)
+    {
+        $this->restart = $restart;
+        $this->startTime = new \DateTime();
+    }
+
+    private function shouldRestart(): bool
+    {
+        return $this->restart && $this->restart->shouldRestart($this->startTime);
+    }
+
+    /**
+     * @throws RestartException
+     */
+    private function checkRestart(): void
+    {
+        if ($this->shouldRestart()) {
+            throw new RestartException();
+        }
+    }
+}

--- a/tests/Driver/AmazonSqsDriverTest.php
+++ b/tests/Driver/AmazonSqsDriverTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Tomaj\Hermes\Test\Driver;
+
+use Aws\Sqs\SqsClient;
+use PHPUnit\Framework\TestCase;
+use Tomaj\Hermes\Driver\AmazonSqsDriver;
+use Tomaj\Hermes\Message;
+use Tomaj\Hermes\MessageSerializer;
+use Tomaj\Hermes\Restart\RestartException;
+
+class AmazonSqsDriverTest extends TestCase
+{
+    private function prepareClient($queue, array $methods = [])
+    {
+        if (!in_array('createQueue', $methods)) {
+            $methods[] = 'createQueue';
+        }
+        $client = $this->getMockBuilder(SqsClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods($methods)
+            ->getMock();
+        $client->expects($this->once())
+            ->method('createQueue')
+            ->with(['QueueName' => 'mykey1', 'Attributes' => []])->will($this->returnValue(new class {
+                public function get($string) {
+                    return 'mykey1';
+                }
+            }));
+        return $client;
+    }
+
+    public function testPredisSendMessage()
+    {
+        $message = new Message('message1key', ['a' => 'b']);
+        $client = $this->prepareClient('xx', ['sendMessage']);
+        $client->expects($this->once())
+            ->method('sendMessage')
+            ->with([
+                'QueueUrl' => 'mykey1',
+                'MessageBody' => (new MessageSerializer)->serialize($message),
+            ]);
+
+        $driver = new AmazonSqsDriver($client, 'mykey1');
+        $driver->send($message);
+    }
+
+    public function testWaitForMessage()
+    {
+        $message = new Message('message1', ['test' => 'value']);
+
+        $client = $this->prepareClient('mykey1', ['receiveMessage', 'deleteMessage']);
+        $client->expects($this->once())
+            ->method('receiveMessage')
+            ->will($this->returnValue(['Messages' => [['ReceiptHandle' => '123x', 'Body' => (new MessageSerializer)->serialize($message)]]]));
+        $client->expects($this->once())
+            ->method('deleteMessage')
+            ->with(['QueueUrl' => 'mykey1', 'ReceiptHandle' => '123x']);
+
+        $driver = new AmazonSqsDriver($client, 'mykey1');
+        $driver->setMaxProcessItems(1);
+        $driver->wait(function ($message) use (&$processed) {
+            $processed[] = $message;
+        });
+
+        $this->assertCount(1, $processed);
+        $this->assertEquals($message->getId(), $processed[0]->getId());
+    }
+
+    public function testRestartBeforeStart()
+    {
+        $client = $this->prepareClient('mykey1', []);
+        $processed = [];
+        $driver = new AmazonSqsDriver($client, 'mykey1');
+        $driver->setRestart(new CustomRestart((new \DateTime())->modify("+5 minutes")));
+
+        $this->expectException(RestartException::class);
+
+        $driver->wait(function ($message) use (&$processed) {
+            $processed[] = $message;
+        });
+    }
+}
+

--- a/tests/Driver/CustomRestart.php
+++ b/tests/Driver/CustomRestart.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tomaj\Hermes\Test\Driver;
+
+use DateTime;
+use Tomaj\Hermes\Restart\RestartInterface;
+
+class CustomRestart implements RestartInterface
+{
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    public function shouldRestart(DateTime $startTime): bool
+    {
+        return $this->dateTime > $startTime;
+    }
+
+    public function restart(DateTime $restartTime = null): bool
+    {
+        $this->dateTime = $restartTime ?? new DateTime();
+    }
+}


### PR DESCRIPTION
Added ability to restart worker from Drivers with `RestartException`. Can be used in drivers that are working via pull mechanism (like _RedisSetDriver_) and not subscribe like _RabbitMqDriver_
Introduced `RestartTrait` for easier control over restarting.

**Implemented in drivers:**
 - RedisSetDriver
 - AmazonSqsDriver
 - LazyRabbitMqDriver

Also added tests for _AmazonSqsDriver_ and _RabbitMqDriver_