### PR TITLE
Fix RedisRestart::restart() for Predis instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+* Fixed `RedisRestart::restart()` response for Predis instance. `\Predis\Client::set()` returns object _(with 'OK' payload)_ instead of bool.
+
 ## 3.0.0 - 2020-10-13
 
 ### Added

--- a/src/Restart/RedisRestart.php
+++ b/src/Restart/RedisRestart.php
@@ -71,6 +71,18 @@ class RedisRestart implements RestartInterface
             $restartTime = new DateTime();
         }
 
-        return $this->redis->set($this->key, $restartTime->format('U'));
+        $response = $this->redis->set($this->key, $restartTime->format('U'));
+
+        if ($this->redis instanceof \Redis) {
+            // \Redis::set() returns TRUE/FALSE
+            return $response;
+        }
+
+        if ($this->redis instanceof \Predis\Client) {
+            /** @var \Predis\Response\Status $response */
+            return $response->getPayload() === 'OK';
+        }
+
+        return false;
     }
 }

--- a/tests/Restart/RedisRestartTest.php
+++ b/tests/Restart/RedisRestartTest.php
@@ -79,5 +79,20 @@ class RedisRestartTest extends TestCase
         $this->assertTrue($redisRestart->restart($restartTime));
     }
 
+    public function testRestartStoredCorrectValueToRedisPredis()
+    {
+        $restartTime = (new \DateTime())->modify('-5 minutes');
+        $redis = $this->getMockBuilder(\Predis\Client::class)
+            ->addMethods(['set'])
+            ->getMock();
+        $redis->expects($this->once())
+            ->method('set')
+            ->with('hermes_restart', $restartTime->format('U'))
+            ->willReturn(new \Predis\Response\Status('OK'));
+
+        $redisRestart = new RedisRestart($redis);
+        $this->assertTrue($redisRestart->restart($restartTime));
+    }
+
 
 }


### PR DESCRIPTION
`\Predis\Client::set()` returns object (with default 'OK' payload) instead of bool like `\Redis::set()`.

Added test to verify response of `RedisRestart::restart()` with Predis instance. (Against mock; won't catch change in \Predis implementation).

---

I missed this in last PR :man_shrugging: 