### PR TITLE
Fix json_encode in MessageSerializer

### DIFF
--- a/src/MessageSerializer.php
+++ b/src/MessageSerializer.php
@@ -19,7 +19,7 @@ class MessageSerializer implements SerializerInterface
                 'execute_at' => $message->getExecuteAt(),
                 'retries' => $message->getRetries(),
             ]
-        ]);
+        ], JSON_INVALID_UTF8_IGNORE);
     }
 
     /**


### PR DESCRIPTION
If there is invalid UTF8 character (usually in payload), json_encode returns false, which is not string :) Hermes failed with error: `Return value of Tomaj\Hermes\MessageSerializer::serialize() must be of the type string, bool returned` With PHP7.2+ option JSON_INVALID_UTF8_IGNORE we can ignore this character and there will be empty string instead. Or we can use option JSON_INVALID_UTF8_SUBSTITUTE and there will be `\ufffd` used. See https://github.com/php/php-src/blob/master/ext/json/tests/json_encode_invalid_utf8.phpt