### PR TITLE
Add v2 and v3 psr/log alternatives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">= 7.2.0",
         "ext-json": "*",
         "ramsey/uuid": "^3 || ^4",
-        "psr/log": "^1.0",
+        "psr/log": "^1 || ^2 || ^3",
         "tracy/tracy": "^2.0"
     },
     "require-dev": {

--- a/tests/Shutdown/StopShutdown.php
+++ b/tests/Shutdown/StopShutdown.php
@@ -13,6 +13,9 @@ class StopShutdown implements ShutdownInterface
 
     public function shouldShutdown(DateTime $startTime): bool
     {
+        if (!isset(self::$eventsStop)) {
+            return false;
+        }
         if (self::$eventsStop === 1) {
             return true;
         }


### PR DESCRIPTION
This is to solve compatibility issues with newer
libraries requiring psr/log:"^3".