### PR TITLE
Feature: Ability to unregister handlers (specific & all)

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -270,6 +270,22 @@ class Dispatcher implements DispatcherInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function unregisterHandler(string $type, HandlerInterface $handler): DispatcherInterface
+    {
+        if (!isset($this->handlers[$type])) {
+            return $this;
+        }
+        $this->handlers[$type] = array_filter(
+            $this->handlers[$type],
+            fn ($registeredHandler) => $registeredHandler !== $handler
+        );
+
+        return $this;
+    }
+
+    /**
      * Serialize message to logger context
      *
      * @param MessageInterface $message

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -261,6 +261,15 @@ class Dispatcher implements DispatcherInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function unregisterAllHandlers(): DispatcherInterface
+    {
+        $this->handlers = [];
+        return $this;
+    }
+
+    /**
      * Serialize message to logger context
      *
      * @param MessageInterface $message

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -38,6 +38,16 @@ interface DispatcherInterface
     public function unregisterAllHandlers(): DispatcherInterface;
 
     /**
+     * Will unregister a specific handler.
+     *
+     * @param string $type
+     * @param HandlerInterface $handler
+     *
+     * @return DispatcherInterface
+     */
+    public function unregisterHandler(string $type, HandlerInterface $handler): DispatcherInterface;
+
+    /**
      * Basic method for background job to star listening.
      *
      * @param int[] $priorities

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -31,6 +31,13 @@ interface DispatcherInterface
     public function registerHandlers(string $type, array $handler): DispatcherInterface;
 
     /**
+     * Will unregister all handlers. This method is useful for testing.
+     *
+     * @return DispatcherInterface
+     */
+    public function unregisterAllHandlers(): DispatcherInterface;
+
+    /**
      * Basic method for background job to star listening.
      *
      * @param int[] $priorities

--- a/tests/HandleTest.php
+++ b/tests/HandleTest.php
@@ -184,4 +184,29 @@ class HandleTest extends TestCase
         $receivedMessages = $handler->getReceivedMessages();
         $this->assertCount(1, $receivedMessages);
     }
+
+    public function testUnregisterHandler(): void
+    {
+        $message1 = new Message('event1', ['a' => 'b']);
+        $message2 = new Message('event2', ['c' => 'd']);
+
+        $driver = new DummyDriver([$message1, $message2]);
+        $dispatcher = new Dispatcher($driver);
+
+        $firstHandler = new TestHandler();
+        $secondHandler = new TestHandler();
+
+        $dispatcher->registerHandler('event1', $firstHandler);
+        $dispatcher->registerHandler('event2', $secondHandler);
+        $dispatcher->handle();
+
+        $dispatcher->unregisterHandler('event2', $secondHandler);
+        $dispatcher->handle();
+
+        $firstHandlerReceivedMessages = $firstHandler->getReceivedMessages();
+        $this->assertCount(2, $firstHandlerReceivedMessages);
+
+        $secondHandlerReceivedMessages = $secondHandler->getReceivedMessages();
+        $this->assertCount(1, $secondHandlerReceivedMessages);
+    }
 }

--- a/tests/HandleTest.php
+++ b/tests/HandleTest.php
@@ -164,4 +164,24 @@ class HandleTest extends TestCase
         $this->assertEquals(['n' => 2], $receivedMessages[0]->getPayload());
         $this->assertEquals(['n' => 1], $receivedMessages[1]->getPayload());
     }
+
+    public function testUnregisterAllHandlers(): void
+    {
+        $message1 = new Message('event1', ['a' => 'b']);
+        $message2 = new Message('event2', ['c' => 'd']);
+
+        $driver = new DummyDriver([$message1, $message2]);
+        $dispatcher = new Dispatcher($driver);
+
+        $handler = new TestHandler();
+
+        $dispatcher->registerHandler('event2', $handler);
+        $dispatcher->handle();
+
+        $dispatcher->unregisterAllHandlers();
+        $dispatcher->handle();
+
+        $receivedMessages = $handler->getReceivedMessages();
+        $this->assertCount(1, $receivedMessages);
+    }
 }


### PR DESCRIPTION
### Added functionality:
- To reset/unregister all handlers
- To unregister a specific handler 

### Reason
We ran into a problem within internal tests when we needed to reset/unregister all handlers after each test. Until now we used to recreate a whole new DI container which started to cause memory leaks. I think we could fix this at the root of the problem.

Thanks. 🙂 