### PR TITLE
Feature fix: Ability to unregister handlers - PHP 7.2 support

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -279,7 +279,9 @@ class Dispatcher implements DispatcherInterface
         }
         $this->handlers[$type] = array_filter(
             $this->handlers[$type],
-            fn ($registeredHandler) => $registeredHandler !== $handler
+            function (HandlerInterface $registeredHandler) use ($handler) {
+                return $registeredHandler !== $handler;
+            }
         );
 
         return $this;


### PR DESCRIPTION
Revert arrow function to support PHP 7.2