### PR TITLE
Remove implicitly nullable parameters

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -57,7 +57,7 @@ class Dispatcher implements DispatcherInterface
      * @param LoggerInterface|null $logger
      * @param ShutdownInterface|null $shutdown
      */
-    public function __construct(DriverInterface $driver, LoggerInterface $logger = null, ShutdownInterface $shutdown = null)
+    public function __construct(DriverInterface $driver, ?LoggerInterface $logger = null, ?ShutdownInterface $shutdown = null)
     {
         $this->driver = $driver;
         $this->logger = $logger;

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -29,7 +29,7 @@ class Emitter implements EmitterInterface
      * @param DriverInterface $driver
      * @param LoggerInterface|null $logger
      */
-    public function __construct(DriverInterface $driver, LoggerInterface $logger = null)
+    public function __construct(DriverInterface $driver, ?LoggerInterface $logger = null)
     {
         $this->driver = $driver;
         $this->logger = $logger;

--- a/src/Message.php
+++ b/src/Message.php
@@ -47,7 +47,7 @@ class Message implements MessageInterface
      * @param float|null $executeAt timestamp (microtime(true))
      * @param int $retries
      */
-    public function __construct(string $type, array $payload = null, string $messageId = null, float $created = null, float $executeAt = null, int $retries = 0)
+    public function __construct(string $type, ?array $payload = null, ?string $messageId = null, ?float $created = null, ?float $executeAt = null, int $retries = 0)
     {
         if ($messageId === null || $messageId == "") {
             $messageId = Uuid::uuid4()->toString();

--- a/src/Shutdown/PredisShutdown.php
+++ b/src/Shutdown/PredisShutdown.php
@@ -61,7 +61,7 @@ class PredisShutdown implements ShutdownInterface
      *
      * Sets to Redis value `$shutdownTime` (or current DateTime) to `$key` defined in constructor.
      */
-    public function shutdown(DateTime $shutdownTime = null): bool
+    public function shutdown(?DateTime $shutdownTime = null): bool
     {
         if ($shutdownTime === null) {
             $shutdownTime = new DateTime();

--- a/src/Shutdown/RedisShutdown.php
+++ b/src/Shutdown/RedisShutdown.php
@@ -60,7 +60,7 @@ class RedisShutdown implements ShutdownInterface
      *
      * Sets to Redis value `$shutdownTime` (or current DateTime) to `$key` defined in constructor.
      */
-    public function shutdown(DateTime $shutdownTime = null): bool
+    public function shutdown(?DateTime $shutdownTime = null): bool
     {
         if ($shutdownTime === null) {
             $shutdownTime = new DateTime();

--- a/src/Shutdown/SharedFileShutdown.php
+++ b/src/Shutdown/SharedFileShutdown.php
@@ -39,7 +39,7 @@ class SharedFileShutdown implements ShutdownInterface
      *
      * Creates file defined in constructor with modification time `$shutdownTime` (or current DateTime).
      */
-    public function shutdown(DateTime $shutdownTime = null): bool
+    public function shutdown(?DateTime $shutdownTime = null): bool
     {
         if ($shutdownTime === null) {
             $shutdownTime = new DateTime();

--- a/src/Shutdown/ShutdownInterface.php
+++ b/src/Shutdown/ShutdownInterface.php
@@ -26,5 +26,5 @@ interface ShutdownInterface
      * @param DateTime|null $shutdownTime (Optional) DateTime when should be Hermes shutdown. If null, current datetime should be used.
      * @return bool
      */
-    public function shutdown(DateTime $shutdownTime = null): bool;
+    public function shutdown(?DateTime $shutdownTime = null): bool;
 }

--- a/tests/Driver/CustomShutdown.php
+++ b/tests/Driver/CustomShutdown.php
@@ -21,7 +21,7 @@ class CustomShutdown implements ShutdownInterface
         return $this->dateTime > $startTime;
     }
 
-    public function shutdown(DateTime $shutdownTime = null): bool
+    public function shutdown(?DateTime $shutdownTime = null): bool
     {
         $this->dateTime = $shutdownTime ?? new DateTime();
         return true;

--- a/tests/Shutdown/StopShutdown.php
+++ b/tests/Shutdown/StopShutdown.php
@@ -23,7 +23,7 @@ class StopShutdown implements ShutdownInterface
         return false;
     }
 
-    public function shutdown(DateTime $shutdownTime = null): bool
+    public function shutdown(?DateTime $shutdownTime = null): bool
     {
         self::$eventsStop = 1;
         return true;


### PR DESCRIPTION
Implicitly nullable parameter declarations are [deprecated from PHP 8.4 on](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) and will be removed in PHP 9. This project uses them in a few places, which is fixed by this PR. Optional parameter types (`?string` etc) are supported from PHP 7.1 on, so we do not impact old PHP versions.

How to reproduce:
```
> docker run --rm -v .:/app "php:8.4-cli" find /app -type f -name "*.php" -exec php -d error_reporting=32765 -l {} \; | grep -v 'No syntax errors detected'
Deprecated: Tomaj\Hermes\Dispatcher::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Dispatcher.php on line 60
Deprecated: Tomaj\Hermes\Dispatcher::__construct(): Implicitly marking parameter $shutdown as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Dispatcher.php on line 60
Deprecated: Tomaj\Hermes\Emitter::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Emitter.php on line 32
Deprecated: Tomaj\Hermes\Message::__construct(): Implicitly marking parameter $payload as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Message.php on line 50
Deprecated: Tomaj\Hermes\Message::__construct(): Implicitly marking parameter $messageId as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Message.php on line 50
Deprecated: Tomaj\Hermes\Message::__construct(): Implicitly marking parameter $created as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Message.php on line 50
Deprecated: Tomaj\Hermes\Message::__construct(): Implicitly marking parameter $executeAt as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Message.php on line 50
Deprecated: Tomaj\Hermes\Shutdown\SharedFileShutdown::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Shutdown/SharedFileShutdown.php on line 42
Deprecated: Tomaj\Hermes\Shutdown\PredisShutdown::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Shutdown/PredisShutdown.php on line 64
Deprecated: Tomaj\Hermes\Shutdown\RedisShutdown::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Shutdown/RedisShutdown.php on line 63
Deprecated: Tomaj\Hermes\Shutdown\ShutdownInterface::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/src/Shutdown/ShutdownInterface.php on line 29
Deprecated: Tomaj\Hermes\Test\Driver\CustomShutdown::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/tests/Driver/CustomShutdown.php on line 24
Deprecated: Tomaj\Hermes\Test\Shutdown\StopShutdown::shutdown(): Implicitly marking parameter $shutdownTime as nullable is deprecated, the explicit nullable type must be used instead in /app/tests/Shutdown/StopShutdown.php on line 26
```

Not fixed in this PR are deprecations in predis and php-amqplib. They'll hopefully resolve when upgrading dependencies.