### PR TITLE
Update gitignore to exclude log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 coverage.clover
 .idea
 .phpunit.cache
+exception.log
+exception--*


### PR DESCRIPTION
Add `exception.log` and `exception--*` to `.gitignore` to prevent tracking of these log files.

---

[Open in Web](https://www.cursor.com/agents?id=bc-bc6e07d8-35ff-4f47-8aaa-97deaa2dfd78) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bc6e07d8-35ff-4f47-8aaa-97deaa2dfd78)