### PR TITLE
Remove code climate and set up local coverage reporting

### DIFF
--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -1,0 +1,66 @@
+name: Deploy Coverage to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["PHPUnit"]
+    types:
+      - completed
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: ./coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create index page
+        run: |
+          cat > ./coverage/README.md << 'EOF'
+          # Code Coverage Report
+          
+          This page contains the code coverage report for the project.
+          
+          - [Coverage Report](./index.html) - Interactive HTML coverage report
+          - Generated from commit: `${{ github.event.workflow_run.head_sha }}`
+          - Branch: `${{ github.event.workflow_run.head_branch }}`
+          - Workflow run: [${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }})
+          
+          ## How to read the coverage report
+          
+          - **Green lines**: Covered by tests
+          - **Red lines**: Not covered by tests  
+          - **Yellow lines**: Partially covered
+          
+          Click on any file in the coverage report to see line-by-line coverage details.
+          EOF
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./coverage
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,10 +38,10 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
 
     - name: Create build directories
-      run: mkdir -p build/logs
+      run: mkdir -p build/logs build/coverage
 
     - name: Run PHPUnit tests
-      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
 
     - if: |
         matrix.php-versions == '8.1' &&
@@ -55,20 +55,10 @@ jobs:
     - if: |
         matrix.php-versions == '8.1' &&
         matrix.operating-system == 'ubuntu-latest'
-      name: Debug coverage file
-      run: |
-        ls -la build/logs/
-        head -20 build/logs/clover.xml || echo "Coverage file not found or empty"
-
-    - if: |
-        matrix.php-versions == '8.1' &&
-        matrix.operating-system == 'ubuntu-latest'
-      name: Upload coverage to Codeclimate
-      continue-on-error: true
-      uses: paambaati/codeclimate-action@v5.0.0
-      env:
-        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      name: Upload coverage reports
+      uses: actions/upload-artifact@v4
       with:
-        coverageLocations: ${{github.workspace}}/build/logs/clover.xml:clover
-        debug: true
+        name: coverage-report
+        path: build/coverage/
+        retention-days: 30
 

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ sniff_fix: vendor/autoload.php
 
 test: vendor/autoload.php
 	vendor/bin/phpunit
+
+coverage: vendor/autoload.php
+	mkdir -p build/logs build/coverage
+	vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test: vendor/autoload.php
 
 coverage: vendor/autoload.php
 	mkdir -p build/logs build/coverage
-	vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
+	XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage

--- a/README.md
+++ b/README.md
@@ -421,6 +421,23 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 $ composer test
 ```
 
+### Code Coverage
+
+To generate code coverage reports:
+
+``` bash
+# Generate coverage reports locally
+$ composer coverage
+# or use the helper script
+$ ./coverage.sh
+```
+
+The coverage reports will be generated in:
+- **HTML report**: `build/coverage/index.html` (open in browser to see line-by-line coverage)
+- **Clover XML**: `build/logs/clover.xml` (for CI/CD integration)
+
+**Online Coverage Reports**: Coverage reports are automatically published to GitHub Pages after each successful test run on the main branch. You can view them at: `https://[username].github.io/[repository-name]/`
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "scripts": {
         "phpunit": "phpunit",
         "phpstan": "phpstan analyse",
-        "phpcs": "phpcs --standard=PSR2 src tests examples -n"
+        "phpcs": "phpcs --standard=PSR2 src tests examples -n",
+        "coverage": "phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,6 @@
         "phpunit": "phpunit",
         "phpstan": "phpstan analyse",
         "phpcs": "phpcs --standard=PSR2 src tests examples -n",
-        "coverage": "phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
+        "coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     }
 }

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Generate code coverage report locally
+echo "Generating code coverage report..."
+
+# Create build directories
+mkdir -p build/logs build/coverage
+
+# Run PHPUnit with coverage
+vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Coverage report generated successfully!"
+    echo ""
+    echo "📊 Coverage reports available at:"
+    echo "   - HTML: build/coverage/index.html"
+    echo "   - Clover XML: build/logs/clover.xml"
+    echo ""
+    echo "🌐 Open the HTML report in your browser:"
+    if command -v xdg-open &> /dev/null; then
+        echo "   xdg-open build/coverage/index.html"
+    elif command -v open &> /dev/null; then
+        echo "   open build/coverage/index.html"
+    else
+        echo "   file://$(pwd)/build/coverage/index.html"
+    fi
+else
+    echo ""
+    echo "❌ Coverage generation failed!"
+    exit 1
+fi

--- a/coverage.sh
+++ b/coverage.sh
@@ -6,8 +6,8 @@ echo "Generating code coverage report..."
 # Create build directories
 mkdir -p build/logs build/coverage
 
-# Run PHPUnit with coverage
-vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
+# Run PHPUnit with coverage (with Xdebug coverage mode)
+XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-html build/coverage
 
 if [ $? -eq 0 ]; then
     echo ""


### PR DESCRIPTION
Remove Code Climate and set up local code coverage reporting with GitHub Pages publication.

This change provides a self-hosted, easily accessible way to view line-by-line code coverage directly from GitHub Pages, and adds local scripts for developers to generate reports.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d6b2a394-3904-4e56-84fa-c3835238d8eb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d6b2a394-3904-4e56-84fa-c3835238d8eb)